### PR TITLE
fix: チャンネル名の重複表示を解消

### DIFF
--- a/mattermost-chat-client/src/components/ChatMiniView.tsx
+++ b/mattermost-chat-client/src/components/ChatMiniView.tsx
@@ -419,11 +419,8 @@ const ChatMiniView: React.FC<ChatMiniViewProps> = ({ channel }) => {
         ) : (
           <Box sx={{ p: 2, textAlign: 'center' }}>
             <Typography variant="body2" color="text.secondary">
-              {channel.icon} {channel.name}
-            </Typography>
-            <Typography variant="caption" color="text.secondary">
               {isRealMattermostChannel(channel.id) 
-                ? 'Mattermostチャンネル - 会話を開始しましょう'
+                ? '会話を開始しましょう'
                 : '⚠️ 非同期チャンネル（Mattermostを使用してください）'}
             </Typography>
             {isRealMattermostChannel(channel.id) && (


### PR DESCRIPTION
## 概要
チャットルームを開いた時にチャンネル名が重複して表示される問題を修正しました。

## 問題
- チャンネル名がタイトルバーとチャット画面内で2箇所に表示
- UI が冗長で使いにくい
- メッセージ表示エリアが圧迫される

## 修正内容

### ChannelListPopup の改善
- ✨ タイトルバーでのチャンネル名表示を強化
- 🎨 アイコン + チャンネル名の併記表示
- 🎯 プライマリカラーでの強調表示
- 📱 長いチャンネル名のオーバーフロー対応
- 🔒 型安全性の向上（ChannelWithPreview対応）

### ChatMiniView の最適化
- ❌ 冗長なチャンネル情報ヘッダーを削除
- 🎯 チャンネル名の重複表示を解消
- 📏 メッセージ表示エリアの拡張
- 🧹 空メッセージ画面の簡潔化

## 改善効果
- ✅ UI の冗長性を解消
- ✅ チャンネル名がタイトルバーのみで明確に表示
- ✅ より広いメッセージ表示エリア
- ✅ すっきりとした使いやすいインターフェース

## スクリーンショット
修正前：チャンネル名が2箇所に表示
修正後：タイトルバーのみに表示され、メッセージエリアが拡張

## テスト
- [x] TypeScript コンパイル通過
- [x] 開発サーバー正常起動
- [x] チャンネル選択・表示動作確認
- [x] レスポンシブデザイン維持

🤖 Generated with [Claude Code](https://claude.ai/code)