### PR TITLE
feat: チャットパネルのドラッグ&ドロップ機能を実装

### DIFF
--- a/mattermost-chat-client/src/components/ChannelListPopup.tsx
+++ b/mattermost-chat-client/src/components/ChannelListPopup.tsx
@@ -52,8 +52,25 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
   // ドラッグ機能を初期化
   const { dragHandleProps, dialogProps, resetPosition } = useDraggable({
     storageKey: 'chat-panel-position',
-    defaultPosition: { x: window.innerWidth - 370, y: 100 }
+    defaultPosition: { x: window.innerWidth - 370, y: window.innerHeight - 580 }
   });
+
+  // ポップアップが開かれるたびに、保存された位置がない場合はデフォルト位置に設定
+  const [hasInitialized, setHasInitialized] = React.useState(false);
+  
+  React.useEffect(() => {
+    if (open && !hasInitialized) {
+      // localStorageに位置が保存されているかチェック
+      const storedPosition = localStorage.getItem('chat-panel-position');
+      if (!storedPosition) {
+        // 保存された位置がない場合、初回表示位置にリセット
+        resetPosition();
+      }
+      setHasInitialized(true);
+    } else if (!open) {
+      setHasInitialized(false);
+    }
+  }, [open, hasInitialized, resetPosition]);
 
   // ChannelWithPreviewをChannelに変換するヘルパー関数
   const convertChannelWithPreviewToChannel = (channelWithPreview: ChannelWithPreview): Channel => {

--- a/mattermost-chat-client/src/components/ChannelListPopup.tsx
+++ b/mattermost-chat-client/src/components/ChannelListPopup.tsx
@@ -8,15 +8,18 @@ import {
   Box,
   Divider,
   Fade,
+  Tooltip,
 } from '@mui/material';
 import {
   Close as CloseIcon,
   ArrowBack as ArrowBackIcon,
   Refresh as RefreshIcon,
+  OpenWith as DragIcon,
 } from '@mui/icons-material';
 import ChatMiniView from './ChatMiniView';
 import ChannelList from './ChannelList';
 import { useApp } from '../contexts/AppContext';
+import { useDraggable } from '../utils/useDraggable';
 import type { ChannelWithPreview } from '../types/mattermost';
 
 interface Channel {
@@ -45,6 +48,12 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
   const [viewState, setViewState] = React.useState<ViewState>('channelList');
   const [selectedChannel, setSelectedChannel] = React.useState<Channel | null>(null);
   const [isRefreshing, setIsRefreshing] = React.useState(false);
+
+  // ドラッグ機能を初期化
+  const { dragHandleProps, dialogProps, resetPosition } = useDraggable({
+    storageKey: 'chat-panel-position',
+    defaultPosition: { x: window.innerWidth - 370, y: 100 }
+  });
 
   // ChannelWithPreviewをChannelに変換するヘルパー関数
   const convertChannelWithPreviewToChannel = (channelWithPreview: ChannelWithPreview): Channel => {
@@ -134,13 +143,9 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
           height: 500,
           maxWidth: '90vw',
           maxHeight: '80vh',
-          position: 'fixed',
-          bottom: 100,
-          right: 20,
-          top: 'auto',
-          left: 'auto',
-          m: 0,
           borderRadius: 2,
+          boxShadow: '0 8px 32px rgba(0,0,0,0.12)',
+          ...dialogProps.style,
         }
       }}
       BackdropProps={{
@@ -149,42 +154,83 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
     >
       <DialogTitle 
         component="div"
+        {...dragHandleProps}
         sx={{ 
           display: 'flex', 
           alignItems: 'center', 
           justifyContent: 'space-between',
           pb: 1,
+          ...dragHandleProps.style,
+          position: 'relative',
+          '&::before': {
+            content: '""',
+            position: 'absolute',
+            top: 8,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: 32,
+            height: 4,
+            backgroundColor: 'divider',
+            borderRadius: 2,
+            opacity: 0.6,
+          }
         }}
       >
         {viewState === 'channelList' ? (
           <>
-            <Typography variant="h6" component="h2">チャット</Typography>
+            <Typography 
+              variant="h6" 
+              component="h2"
+              onDoubleClick={resetPosition}
+              sx={{ cursor: 'pointer' }}
+              title="ダブルクリックで位置をリセット"
+            >
+              チャット
+            </Typography>
             <Box sx={{ display: 'flex', gap: 1 }}>
-              <IconButton 
-                onClick={handleRefreshChannels} 
-                size="small"
-                disabled={isRefreshing || state.isLoading}
-                title="チャンネルリストを更新"
-              >
-                <RefreshIcon sx={{ 
-                  animation: isRefreshing ? 'spin 1s linear infinite' : 'none',
-                  '@keyframes spin': {
-                    '0%': { transform: 'rotate(0deg)' },
-                    '100%': { transform: 'rotate(360deg)' }
-                  }
-                }} />
-              </IconButton>
-              <IconButton onClick={onClose} size="small">
-                <CloseIcon />
-              </IconButton>
+              <Tooltip title="チャンネルリストを更新">
+                <IconButton 
+                  onClick={handleRefreshChannels} 
+                  size="small"
+                  disabled={isRefreshing || state.isLoading}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onTouchStart={(e) => e.stopPropagation()}
+                >
+                  <RefreshIcon sx={{ 
+                    animation: isRefreshing ? 'spin 1s linear infinite' : 'none',
+                    '@keyframes spin': {
+                      '0%': { transform: 'rotate(0deg)' },
+                      '100%': { transform: 'rotate(360deg)' }
+                    }
+                  }} />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="閉じる">
+                <IconButton 
+                  onClick={onClose} 
+                  size="small"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onTouchStart={(e) => e.stopPropagation()}
+                >
+                  <CloseIcon />
+                </IconButton>
+              </Tooltip>
             </Box>
           </>
         ) : (
           <>
             <Box sx={{ display: 'flex', alignItems: 'center', flex: 1 }}>
-              <IconButton onClick={handleBackToChannelList} size="small" sx={{ mr: 1 }}>
-                <ArrowBackIcon />
-              </IconButton>
+              <Tooltip title="チャンネル一覧に戻る">
+                <IconButton 
+                  onClick={handleBackToChannelList} 
+                  size="small" 
+                  sx={{ mr: 1 }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onTouchStart={(e) => e.stopPropagation()}
+                >
+                  <ArrowBackIcon />
+                </IconButton>
+              </Tooltip>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, minWidth: 0 }}>
                 <Typography 
                   variant="body1" 
@@ -195,22 +241,32 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
                 <Typography 
                   variant="h6" 
                   component="h2" 
+                  onDoubleClick={resetPosition}
                   sx={{ 
                     fontWeight: 'bold',
                     color: 'primary.main',
                     minWidth: 0,
                     overflow: 'hidden',
                     textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap'
+                    whiteSpace: 'nowrap',
+                    cursor: 'pointer'
                   }}
+                  title="ダブルクリックで位置をリセット"
                 >
                   {selectedChannel?.name || 'チャンネル'}
                 </Typography>
               </Box>
             </Box>
-            <IconButton onClick={onClose} size="small">
-              <CloseIcon />
-            </IconButton>
+            <Tooltip title="閉じる">
+              <IconButton 
+                onClick={onClose} 
+                size="small"
+                onMouseDown={(e) => e.stopPropagation()}
+                onTouchStart={(e) => e.stopPropagation()}
+              >
+                <CloseIcon />
+              </IconButton>
+            </Tooltip>
           </>
         )}
       </DialogTitle>

--- a/mattermost-chat-client/src/components/ChannelListPopup.tsx
+++ b/mattermost-chat-client/src/components/ChannelListPopup.tsx
@@ -55,6 +55,11 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
     defaultPosition: { x: window.innerWidth - 370, y: window.innerHeight - 580 }
   });
 
+  // イベント伝播を停止するヘルパー関数
+  const stopEventPropagation = React.useCallback((e: React.MouseEvent | React.TouchEvent) => {
+    e.stopPropagation();
+  }, []);
+
   // ポップアップが開かれるたびに、保存された位置がない場合はデフォルト位置に設定
   const [hasInitialized, setHasInitialized] = React.useState(false);
   
@@ -173,11 +178,11 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
         component="div"
         {...dragHandleProps}
         sx={{ 
+          ...dragHandleProps.style,
           display: 'flex', 
           alignItems: 'center', 
           justifyContent: 'space-between',
           pb: 1,
-          ...dragHandleProps.style,
           position: 'relative',
           '&::before': {
             content: '""',
@@ -210,8 +215,8 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
                   onClick={handleRefreshChannels} 
                   size="small"
                   disabled={isRefreshing || state.isLoading}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  onTouchStart={(e) => e.stopPropagation()}
+                  onMouseDown={stopEventPropagation}
+                  onTouchStart={stopEventPropagation}
                 >
                   <RefreshIcon sx={{ 
                     animation: isRefreshing ? 'spin 1s linear infinite' : 'none',
@@ -226,8 +231,8 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
                 <IconButton 
                   onClick={onClose} 
                   size="small"
-                  onMouseDown={(e) => e.stopPropagation()}
-                  onTouchStart={(e) => e.stopPropagation()}
+                  onMouseDown={stopEventPropagation}
+                  onTouchStart={stopEventPropagation}
                 >
                   <CloseIcon />
                 </IconButton>
@@ -242,8 +247,8 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
                   onClick={handleBackToChannelList} 
                   size="small" 
                   sx={{ mr: 1 }}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  onTouchStart={(e) => e.stopPropagation()}
+                  onMouseDown={stopEventPropagation}
+                  onTouchStart={stopEventPropagation}
                 >
                   <ArrowBackIcon />
                 </IconButton>
@@ -278,8 +283,8 @@ const ChannelListPopup: React.FC<ChannelListPopupProps> = ({
               <IconButton 
                 onClick={onClose} 
                 size="small"
-                onMouseDown={(e) => e.stopPropagation()}
-                onTouchStart={(e) => e.stopPropagation()}
+                onMouseDown={stopEventPropagation}
+                onTouchStart={stopEventPropagation}
               >
                 <CloseIcon />
               </IconButton>

--- a/mattermost-chat-client/src/utils/useDraggable.ts
+++ b/mattermost-chat-client/src/utils/useDraggable.ts
@@ -28,13 +28,15 @@ interface UseDraggableOptions {
     bottom?: number;
   };
   storageKey?: string;
+  resetOnOpen?: boolean; // 開くたびに初期位置にリセットするか
 }
 
 export const useDraggable = (options: UseDraggableOptions = {}): DraggableState => {
   const {
-    defaultPosition = { x: window.innerWidth - 370, y: 100 }, // 右下からのデフォルト位置
+    defaultPosition = { x: window.innerWidth - 370, y: window.innerHeight - 580 }, // 右下のチャットボタン近く
     bounds,
-    storageKey = 'draggable-panel-position'
+    storageKey = 'draggable-panel-position',
+    resetOnOpen = false
   } = options;
 
   // localStorageから保存された位置を読み込み

--- a/mattermost-chat-client/src/utils/useDraggable.ts
+++ b/mattermost-chat-client/src/utils/useDraggable.ts
@@ -1,0 +1,234 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface DraggableState {
+  position: Position;
+  isDragging: boolean;
+  dragHandleProps: {
+    onMouseDown: (e: React.MouseEvent) => void;
+    onTouchStart: (e: React.TouchEvent) => void;
+    style: React.CSSProperties;
+  };
+  dialogProps: {
+    style: React.CSSProperties;
+  };
+  resetPosition: () => void;
+}
+
+interface UseDraggableOptions {
+  defaultPosition?: Position;
+  bounds?: {
+    left?: number;
+    top?: number;
+    right?: number;
+    bottom?: number;
+  };
+  storageKey?: string;
+}
+
+export const useDraggable = (options: UseDraggableOptions = {}): DraggableState => {
+  const {
+    defaultPosition = { x: window.innerWidth - 370, y: 100 }, // 右下からのデフォルト位置
+    bounds,
+    storageKey = 'draggable-panel-position'
+  } = options;
+
+  // localStorageから保存された位置を読み込み
+  const getStoredPosition = (): Position => {
+    if (typeof window !== 'undefined' && storageKey) {
+      try {
+        const stored = localStorage.getItem(storageKey);
+        if (stored) {
+          const parsed = JSON.parse(stored);
+          // 画面サイズが変わった場合の調整
+          return {
+            x: Math.min(Math.max(parsed.x, 0), window.innerWidth - 350),
+            y: Math.min(Math.max(parsed.y, 0), window.innerHeight - 500)
+          };
+        }
+      } catch (error) {
+        console.warn('ドラッグ位置の復元に失敗しました:', error);
+      }
+    }
+    return defaultPosition;
+  };
+
+  const [position, setPosition] = useState<Position>(getStoredPosition);
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef<Position>({ x: 0, y: 0 });
+  const elementStartRef = useRef<Position>({ x: 0, y: 0 });
+
+  // 位置をlocalStorageに保存
+  const savePosition = useCallback((newPosition: Position) => {
+    if (typeof window !== 'undefined' && storageKey) {
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(newPosition));
+      } catch (error) {
+        console.warn('ドラッグ位置の保存に失敗しました:', error);
+      }
+    }
+  }, [storageKey]);
+
+  // 境界チェックを行う関数
+  const constrainPosition = useCallback((pos: Position): Position => {
+    const padding = 20; // 画面端からの最小距離
+    const panelWidth = 350;
+    const panelHeight = 500;
+
+    let constrainedX = pos.x;
+    let constrainedY = pos.y;
+
+    // カスタム境界がある場合
+    if (bounds) {
+      if (bounds.left !== undefined) constrainedX = Math.max(constrainedX, bounds.left);
+      if (bounds.right !== undefined) constrainedX = Math.min(constrainedX, bounds.right - panelWidth);
+      if (bounds.top !== undefined) constrainedY = Math.max(constrainedY, bounds.top);
+      if (bounds.bottom !== undefined) constrainedY = Math.min(constrainedY, bounds.bottom - panelHeight);
+    } else {
+      // デフォルト境界（画面サイズ）
+      constrainedX = Math.max(padding, Math.min(constrainedX, window.innerWidth - panelWidth - padding));
+      constrainedY = Math.max(padding, Math.min(constrainedY, window.innerHeight - panelHeight - padding));
+    }
+
+    return { x: constrainedX, y: constrainedY };
+  }, [bounds]);
+
+  // マウスダウン/タッチスタートのハンドラ
+  const handleDragStart = useCallback((clientX: number, clientY: number) => {
+    setIsDragging(true);
+    dragStartRef.current = { x: clientX, y: clientY };
+    elementStartRef.current = { ...position };
+    document.body.style.userSelect = 'none'; // テキスト選択を無効化
+  }, [position]);
+
+  // マウスムーブ/タッチムーブのハンドラ
+  const handleDragMove = useCallback((clientX: number, clientY: number) => {
+    if (!isDragging) return;
+
+    const deltaX = clientX - dragStartRef.current.x;
+    const deltaY = clientY - dragStartRef.current.y;
+
+    const newPosition = constrainPosition({
+      x: elementStartRef.current.x + deltaX,
+      y: elementStartRef.current.y + deltaY
+    });
+
+    setPosition(newPosition);
+  }, [isDragging, constrainPosition]);
+
+  // ドラッグ終了のハンドラ
+  const handleDragEnd = useCallback(() => {
+    if (isDragging) {
+      setIsDragging(false);
+      document.body.style.userSelect = ''; // テキスト選択を再有効化
+      savePosition(position);
+    }
+  }, [isDragging, position, savePosition]);
+
+  // マウスイベントのリスナー
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      e.preventDefault();
+      handleDragMove(e.clientX, e.clientY);
+    };
+
+    const handleMouseUp = () => {
+      handleDragEnd();
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, handleDragMove, handleDragEnd]);
+
+  // タッチイベントのリスナー
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleTouchMove = (e: TouchEvent) => {
+      e.preventDefault();
+      const touch = e.touches[0];
+      if (touch) {
+        handleDragMove(touch.clientX, touch.clientY);
+      }
+    };
+
+    const handleTouchEnd = () => {
+      handleDragEnd();
+    };
+
+    document.addEventListener('touchmove', handleTouchMove, { passive: false });
+    document.addEventListener('touchend', handleTouchEnd);
+
+    return () => {
+      document.removeEventListener('touchmove', handleTouchMove);
+      document.removeEventListener('touchend', handleTouchEnd);
+    };
+  }, [isDragging, handleDragMove, handleDragEnd]);
+
+  // ウィンドウリサイズ時の位置調整
+  useEffect(() => {
+    const handleResize = () => {
+      setPosition(current => constrainPosition(current));
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [constrainPosition]);
+
+  // 位置リセット関数
+  const resetPosition = useCallback(() => {
+    const newPosition = constrainPosition(defaultPosition);
+    setPosition(newPosition);
+    savePosition(newPosition);
+  }, [constrainPosition, defaultPosition, savePosition]);
+
+  return {
+    position,
+    isDragging,
+    dragHandleProps: {
+      onMouseDown: (e: React.MouseEvent) => {
+        e.preventDefault();
+        handleDragStart(e.clientX, e.clientY);
+      },
+      onTouchStart: (e: React.TouchEvent) => {
+        e.preventDefault();
+        const touch = e.touches[0];
+        if (touch) {
+          handleDragStart(touch.clientX, touch.clientY);
+        }
+      },
+      style: {
+        cursor: isDragging ? 'grabbing' : 'grab',
+        userSelect: 'none' as const,
+        touchAction: 'none'
+      }
+    },
+    dialogProps: {
+      style: {
+        position: 'fixed' as const,
+        left: position.x,
+        top: position.y,
+        right: 'auto',
+        bottom: 'auto',
+        margin: 0,
+        transform: 'none',
+        opacity: isDragging ? 0.8 : 1,
+        transition: isDragging ? 'none' : 'opacity 0.2s ease-in-out'
+      }
+    },
+    resetPosition
+  };
+};
+
+export default useDraggable;


### PR DESCRIPTION
## Summary
- チャットパネルにドラッグ&ドロップ機能を追加
- タイトルバーをドラッグハンドルとして使用可能
- 位置情報をlocalStorageで永続化
- 初期表示位置を右下チャットボタン近くに調整

## 機能詳細
### 🔧 ドラッグ機能
- タイトルバー全体がドラッグハンドル
- マウス/タッチデバイス両対応
- 画面境界での制限（パネルが画面外に出ない）
- ドラッグ中の視覚的フィードバック（透明度変更）

### 💾 位置永続化
- ドラッグした位置をlocalStorageに自動保存
- セッション間での位置復元
- ウィンドウリサイズ時の自動位置調整

### 🎨 UX改善
- 上部にドラッグインジケーター表示
- タイトルダブルクリックでデフォルト位置にリセット
- ボタンクリック時のドラッグ防止
- 初期表示位置を右下チャットボタン近くに配置

## 技術実装
### 新規ファイル
- `src/utils/useDraggable.ts` - ドラッグ機能の汎用カスタムフック

### 変更ファイル
- `src/components/ChannelListPopup.tsx` - ドラッグ機能とUI改善

### 主要な技術要素
- React Hooks (`useState`, `useEffect`, `useCallback`)
- マウス/タッチイベントハンドリング
- localStorage API
- Material-UI スタイリング

## Test plan
- [x] タイトルバーをドラッグして移動
- [x] 位置が画面境界内に制限される
- [x] ドラッグした位置が保存・復元される
- [x] タイトルダブルクリックで位置リセット
- [x] ボタン操作時にドラッグが発生しない
- [x] 初期表示位置が右下チャットボタン近く
- [x] モバイルタッチデバイスでの動作

🤖 Generated with [Claude Code](https://claude.ai/code)