### PR TITLE
feat: チャンネルリスト改善とメンション機能の実装

### DIFF
--- a/mattermost-chat-client/src/components/ChannelList.tsx
+++ b/mattermost-chat-client/src/components/ChannelList.tsx
@@ -33,7 +33,7 @@ const ChannelList: React.FC<ChannelListProps> = ({ onChannelSelect }) => {
   const { channels, currentChannel, currentTeam } = state;
   const [channelsWithPreview, setChannelsWithPreview] = React.useState<ChannelWithPreview[]>([]);
   const [isLoadingPreviews, setIsLoadingPreviews] = React.useState(false);
-  const [filterText, setFilterText] = React.useState('佐藤'); // デフォルトで「佐藤」フィルターを適用
+  const [filterText, setFilterText] = React.useState(''); // デフォルトは空（フィルターなし）
   const [filteredChannels, setFilteredChannels] = React.useState<ChannelWithPreview[]>([]);
 
   // チャンネルプレビューの読み込み

--- a/mattermost-chat-client/src/components/MentionSuggestions.tsx
+++ b/mattermost-chat-client/src/components/MentionSuggestions.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import {
+  Paper,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemAvatar,
+  ListItemText,
+  Avatar,
+  Typography,
+  Popper,
+  CircularProgress,
+  Box,
+} from '@mui/material';
+import type { User } from '../types/mattermost';
+
+interface MentionSuggestionsProps {
+  anchorEl: HTMLElement | null;
+  users: User[];
+  selectedIndex: number;
+  isLoading: boolean;
+  onSelectUser: (user: User) => void;
+}
+
+const MentionSuggestions: React.FC<MentionSuggestionsProps> = ({
+  anchorEl,
+  users,
+  selectedIndex,
+  isLoading,
+  onSelectUser,
+}) => {
+  const open = Boolean(anchorEl) && (users.length > 0 || isLoading);
+
+  // ユーザーの表示名を取得
+  const getUserDisplayName = (user: User): string => {
+    return user.nickname || user.username || 'Unknown User';
+  };
+
+  // ユーザーのイニシャルを取得
+  const getUserInitials = (user: User): string => {
+    const displayName = getUserDisplayName(user);
+    return displayName
+      .split(' ')
+      .map(part => part.charAt(0))
+      .join('')
+      .toUpperCase()
+      .slice(0, 2);
+  };
+
+  return (
+    <Popper
+      open={open}
+      anchorEl={anchorEl}
+      placement="top-start"
+      style={{ zIndex: 1301 }}
+    >
+      <Paper
+        elevation={8}
+        sx={{
+          maxHeight: 300,
+          overflow: 'auto',
+          minWidth: 250,
+          maxWidth: 400,
+        }}
+      >
+        {isLoading ? (
+          <Box sx={{ p: 2, display: 'flex', justifyContent: 'center' }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : (
+          <List dense sx={{ py: 0 }}>
+            {users.map((user, index) => (
+              <ListItem key={user.id} disablePadding>
+                <ListItemButton
+                  selected={index === selectedIndex}
+                  onClick={() => onSelectUser(user)}
+                  sx={{
+                    '&.Mui-selected': {
+                      backgroundColor: 'primary.main',
+                      color: 'primary.contrastText',
+                      '&:hover': {
+                        backgroundColor: 'primary.dark',
+                      },
+                      '& .MuiListItemText-primary': {
+                        color: 'inherit',
+                      },
+                      '& .MuiListItemText-secondary': {
+                        color: 'inherit',
+                        opacity: 0.8,
+                      },
+                    },
+                  }}
+                >
+                  <ListItemAvatar>
+                    <Avatar
+                      sx={{
+                        width: 32,
+                        height: 32,
+                        fontSize: '0.875rem',
+                        bgcolor: index === selectedIndex ? 'primary.contrastText' : 'primary.main',
+                        color: index === selectedIndex ? 'primary.main' : 'primary.contrastText',
+                      }}
+                    >
+                      {getUserInitials(user)}
+                    </Avatar>
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={
+                      <Typography variant="body2" component="span">
+                        <strong>@{user.username}</strong>
+                        {user.nickname && user.nickname !== user.username && (
+                          <span style={{ marginLeft: 8 }}>({user.nickname})</span>
+                        )}
+                      </Typography>
+                    }
+                    secondary={
+                      user.first_name || user.last_name ? (
+                        <Typography variant="caption" component="span">
+                          {[user.first_name, user.last_name].filter(Boolean).join(' ')}
+                        </Typography>
+                      ) : null
+                    }
+                  />
+                </ListItemButton>
+              </ListItem>
+            ))}
+            {users.length === 0 && !isLoading && (
+              <ListItem>
+                <ListItemText
+                  primary={
+                    <Typography variant="body2" color="text.secondary" align="center">
+                      ユーザーが見つかりません
+                    </Typography>
+                  }
+                />
+              </ListItem>
+            )}
+          </List>
+        )}
+      </Paper>
+    </Popper>
+  );
+};
+
+export default MentionSuggestions;

--- a/mattermost-chat-client/src/contexts/AppContext.tsx
+++ b/mattermost-chat-client/src/contexts/AppContext.tsx
@@ -768,10 +768,16 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
       console.log('🏢 チーム選択開始:', { teamId: team.id, teamName: team.display_name || team.name });
       dispatch({ type: 'SET_CURRENT_TEAM', payload: team });
       
-      // チームのチャンネル一覧を取得
-      console.log('📡 チャンネル一覧取得開始...', { teamId: team.id, teamName: team.display_name || team.name });
-      const channels = await client.getChannelsForTeam(team.id);
-      console.log('📋 取得したチャンネル一覧:', channels.map(ch => ({
+      // ユーザーが参加しているチャンネルのみを取得
+      console.log('📡 参加チャンネル一覧取得開始...', { teamId: team.id, teamName: team.display_name || team.name });
+      
+      if (!state.user) {
+        console.error('❌ ユーザー情報が存在しません');
+        throw new Error('ユーザー情報が必要です');
+      }
+      
+      const channels = await client.getMyChannelsForTeam(state.user.id, team.id);
+      console.log('📋 取得した参加チャンネル一覧:', channels.map(ch => ({
         id: ch.id,
         name: ch.display_name || ch.name,
         type: ch.type,
@@ -978,6 +984,11 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
       return;
     }
 
+    if (!state.user) {
+      console.error('❌ ユーザー情報が存在しません');
+      return;
+    }
+
     dispatch({ type: 'SET_LOADING', payload: true });
     
     try {
@@ -987,9 +998,9 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
         currentChannelsCount: state.channels.length
       });
       
-      // 最新のチャンネル一覧を取得
-      const channels = await client.getChannelsForTeam(state.currentTeam.id);
-      console.log('📋 更新されたチャンネル一覧:', channels.map(ch => ({
+      // ユーザーが参加している最新のチャンネル一覧を取得
+      const channels = await client.getMyChannelsForTeam(state.user.id, state.currentTeam.id);
+      console.log('📋 更新された参加チャンネル一覧:', channels.map(ch => ({
         id: ch.id,
         name: ch.display_name || ch.name,
         type: ch.type


### PR DESCRIPTION
## Summary
- チャンネルリストの絞り込み初期値を空に変更
- 参加しているチャンネルのみを表示
- メンション機能を実装

## 実装詳細

### 1. チャンネルリストの絞り込み初期値
- 「佐藤」がデフォルトで入っていた問題を修正
- 初期値を空文字列に変更

### 2. 参加チャンネルのみ表示
- **新規API追加**: `getMyChannelsForTeam` - ユーザーが参加しているチャンネルのみを取得
- **AppContext修正**: `selectTeam`と`refreshChannels`で新APIを使用
- ユーザーが参加していないチャンネルは表示されない

### 3. メンション機能
- **ユーザー検索API**: `/users/search`エンドポイントを追加
- **UI実装**: 
  - `@`入力時にユーザー候補をポップアップ表示
  - リアルタイム検索（300msデバウンス）
  - キーボードナビゲーション対応
- **操作方法**:
  - `@`を入力するとユーザー検索開始
  - 矢印キーで候補を選択
  - Enterで確定、Escapeでキャンセル

## 技術的な変更点

### 新規ファイル
- `src/components/MentionSuggestions.tsx` - メンション候補表示コンポーネント

### 変更ファイル
- `src/api/mattermost.ts` - ユーザー検索APIとチャンネル取得APIの追加
- `src/contexts/AppContext.tsx` - 参加チャンネルのみ取得するように変更
- `src/components/ChannelList.tsx` - フィルター初期値の修正
- `src/components/MessageInput.tsx` - メンション機能の統合

## Test plan
- [x] チャンネルリストの絞り込みが空で表示される
- [x] 参加しているチャンネルのみが表示される
- [x] @を入力するとユーザー候補が表示される
- [x] 矢印キーで候補を選択できる
- [x] Enterでユーザーを選択できる
- [x] 選択したユーザー名が正しく挿入される
- [x] スペースを入力するとメンション候補が閉じる

## 注意事項
- Mattermostサーバーでユーザーが作成されている必要があります
- チャンネルに参加していない場合、そのチャンネルは表示されません

🤖 Generated with [Claude Code](https://claude.ai/code)